### PR TITLE
Add dependencies to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Programming Language :: Python :: Implementation :: PyPy",
 ]
 
-dependencies = ["click", "pandas"]
+dependencies = ["click", "pandas", "freezegun", "pydantic"]
 
 
 [project.urls]


### PR DESCRIPTION
Otherwise simple commands such has `hatch test` fail because of missing modules (e.g `freezegun`, `pydantic`, etc.)