### PR TITLE
Fix pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ dynamic = ["version"]
 description = 'Study version manager for Antares ecosystem'
 readme = "README.md"
 requires-python = ">=3.8"
-license = "MIT"
+license = { text = "MIT" }
 keywords = ["antares", "study", "config", "configuration", "model", "versionning"]
 authors = [
     { name = "Laurent LAPORTE", email = "laurent.laporte.pro@gmail.com" },


### PR DESCRIPTION
Otherwise setuptools returns an error like this when running e.g `python3 -m build`
```
ValueError: invalid pyproject.toml config: `project.license`.
configuration error: `project.license` must be valid exactly by one definition (2 matches found):

    - keys:
        'file': {type: string}
      required: ['file']
    - keys:
        'text': {type: string}
      required: ['text']
```