### PR TITLE
chore(pyproject): add config to keep zip files in the final package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,9 @@ Documentation = "https://github.com/AntaresSimulatorTeam/antares-study-version#r
 Issues = "https://github.com/AntaresSimulatorTeam/antares-study-version/issues"
 Source = "https://github.com/AntaresSimulatorTeam/antares-study-version"
 
+[tool.setuptools.data-files]
+antares = ["src/antares/study/version/create_app/resources/*.zip"]
+
 [tool.mypy]
 files = ["src/", "tests/"]
 ignore_missing_imports = true


### PR DESCRIPTION
This PR is linked to the #[ANT-2716](https://gopro-tickets.rte-france.com/browse/ANT-2716)

The package built and uploaded to Pypi does not include the study templates in `.zip` files. This PR should resolve this issue by addind a `data-files` config in the `pyproject.toml`.