### PR TITLE
fix(desktop): use pyinstaller specefic dir on desktop

### DIFF
--- a/src/antares/study/version/create_app/__init__.py
+++ b/src/antares/study/version/create_app/__init__.py
@@ -1,5 +1,6 @@
 import dataclasses
 import datetime
+import sys
 import typing as t
 import zipfile
 from pathlib import Path
@@ -19,8 +20,9 @@ def get_template_version(template_name: str) -> StudyVersion:
 
 
 TEMPLATES_BY_VERSIONS: t.Dict[StudyVersion, str] = {}
-REL_RESOURCES_PATH = _RESOURCES_PATH.relative_to(Path.cwd())
-for resource in REL_RESOURCES_PATH.iterdir():
+if getattr(sys, 'frozen', False) and hasattr(sys, '_MEIPASS'):
+    _RESOURCES_PATH = Path(sys._MEIPASS) / "resources"
+for resource in _RESOURCES_PATH.iterdir():
     if resource.name.endswith(".zip"):
         TEMPLATES_BY_VERSIONS[get_template_version(resource.name)] = resource.name
 

--- a/src/antares/study/version/create_app/__init__.py
+++ b/src/antares/study/version/create_app/__init__.py
@@ -19,7 +19,8 @@ def get_template_version(template_name: str) -> StudyVersion:
 
 
 TEMPLATES_BY_VERSIONS: t.Dict[StudyVersion, str] = {}
-for resource in _RESOURCES_PATH.iterdir():
+REL_RESOURCES_PATH = _RESOURCES_PATH.relative_to(HERE.parent)
+for resource in REL_RESOURCES_PATH.iterdir():
     if resource.name.endswith(".zip"):
         TEMPLATES_BY_VERSIONS[get_template_version(resource.name)] = resource.name
 

--- a/src/antares/study/version/create_app/__init__.py
+++ b/src/antares/study/version/create_app/__init__.py
@@ -19,7 +19,7 @@ def get_template_version(template_name: str) -> StudyVersion:
 
 
 TEMPLATES_BY_VERSIONS: t.Dict[StudyVersion, str] = {}
-REL_RESOURCES_PATH = _RESOURCES_PATH.relative_to(HERE.parent)
+REL_RESOURCES_PATH = _RESOURCES_PATH.relative_to(Path.cwd())
 for resource in REL_RESOURCES_PATH.iterdir():
     if resource.name.endswith(".zip"):
         TEMPLATES_BY_VERSIONS[get_template_version(resource.name)] = resource.name

--- a/src/antares/study/version/create_app/__init__.py
+++ b/src/antares/study/version/create_app/__init__.py
@@ -1,5 +1,5 @@
 import dataclasses
-
+import datetime
 import sys
 import typing as t
 import zipfile

--- a/src/antares/study/version/create_app/__init__.py
+++ b/src/antares/study/version/create_app/__init__.py
@@ -1,5 +1,5 @@
 import dataclasses
-import datetime
+
 import sys
 import typing as t
 import zipfile
@@ -11,6 +11,11 @@ from antares.study.version.model.study_version import StudyVersion
 
 HERE = Path(__file__).resolve()
 _RESOURCES_PATH = HERE.parent / "resources"
+# If the application is running in a frozen state (e.g., packaged with PyInstaller),
+# set the resources path to the temporary directory (_MEIPASS) created by PyInstaller.
+# details here : https://pyinstaller.org/en/stable/runtime-information.html
+if getattr(sys, "frozen", False) and hasattr(sys, "_MEIPASS"):
+    _RESOURCES_PATH = Path(sys._MEIPASS) / "resources"
 
 
 def get_template_version(template_name: str) -> StudyVersion:
@@ -20,8 +25,6 @@ def get_template_version(template_name: str) -> StudyVersion:
 
 
 TEMPLATES_BY_VERSIONS: t.Dict[StudyVersion, str] = {}
-if getattr(sys, 'frozen', False) and hasattr(sys, '_MEIPASS'):
-    _RESOURCES_PATH = Path(sys._MEIPASS) / "resources"
 for resource in _RESOURCES_PATH.iterdir():
     if resource.name.endswith(".zip"):
         TEMPLATES_BY_VERSIONS[get_template_version(resource.name)] = resource.name


### PR DESCRIPTION
When a desktop artifact is built with pyinstaller, it does't run in a normal python process but in a bundled artifact. Because of this we can't access resources using their path.

When a bundled app starts up, PyInstakker sets the sys.frozen attribute and stores the absolute path to the bundle folder in sys._MEIPASS. 

