### PR TITLE
fix(desktop): add pyinstaller hooks to collect zip files 

### DIFF
--- a/hook-antares.study.version.py
+++ b/hook-antares.study.version.py
@@ -1,0 +1,3 @@
+from PyInstaller.utils.hooks import collect_data_files
+
+datas = collect_data_files('antares.study.version.create_app.resources')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "antares-study-version"
-version = "1.0.17"
+version = "1.0.16"
 description = 'Study version manager for Antares ecosystem'
 readme = "README.md"
 requires-python = ">=3.8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "antares-study-version"
-version = "1.0.16"
+version = "1.0.17"
 description = 'Study version manager for Antares ecosystem'
 readme = "README.md"
 requires-python = ">=3.8"
@@ -130,3 +130,8 @@ docstring-code-format = true
 # This only has an effect when the `docstring-code-format` setting is
 # enabled.
 docstring-code-line-length = "dynamic"
+
+
+[project.entry-points."pyinstaller40"]
+hook-dirs = "antares.study.version.__pyinstaller:get_hook_dirs"
+tests = "antares.study.version.__pyinstaller:get_PyInstaller_tests"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -134,4 +134,3 @@ docstring-code-line-length = "dynamic"
 
 [project.entry-points."pyinstaller40"]
 hook-dirs = "antares.study.version.__pyinstaller:get_hook_dirs"
-tests = "antares.study.version.__pyinstaller:get_PyInstaller_tests"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,3 +7,5 @@ mypy~=1.15.0; python_version > '3.8'
 mypy~=1.14.0; python_version <= '3.8'
 pandas-stubs~=2.2.3; python_version > '3.9'
 pandas-stubs~=2.0.3; python_version <= '3.9'
+pyinstaller==6.10.0
+pyinstaller-hooks-contrib==2024.8

--- a/src/antares/study/version/__pyinstaller/__init__.py
+++ b/src/antares/study/version/__pyinstaller/__init__.py
@@ -10,17 +10,3 @@ def get_hook_dirs():
     """
 
     return [os.path.dirname(__file__)]
-
-
-def get_PyInstaller_tests():
-    """
-    Retrieve the directory path where pyinstaller will look for test hooks.
-
-    These paths are then passed to pytest for test discovery. This allows both
-    testing by this package and by PyInstaller.
-
-    Returns:
-        list: A list with the directory path of the test hooks.
-    """
-
-    return [os.path.dirname(__file__)]

--- a/src/antares/study/version/__pyinstaller/__init__.py
+++ b/src/antares/study/version/__pyinstaller/__init__.py
@@ -1,0 +1,26 @@
+import os
+
+
+def get_hook_dirs():
+    """
+    Retrieve the directory path where pyinstaller will look for hooks.
+
+    Returns:
+        list: A list with the directory path of the hooks.
+    """
+
+    return [os.path.dirname(__file__)]
+
+
+def get_PyInstaller_tests():
+    """
+    Retrieve the directory path where pyinstaller will look for test hooks.
+
+    These paths are then passed to pytest for test discovery. This allows both
+    testing by this package and by PyInstaller.
+
+    Returns:
+        list: A list with the directory path of the test hooks.
+    """
+
+    return [os.path.dirname(__file__)]

--- a/src/antares/study/version/__pyinstaller/hook-antares.study.version.py
+++ b/src/antares/study/version/__pyinstaller/hook-antares.study.version.py
@@ -1,5 +1,5 @@
 from PyInstaller.utils.hooks import collect_data_files
 
-hiddenimports = ['antares.study.version.create_app.resources']
+hiddenimports = ["antares.study.version.create_app.resources"]
 
-datas = collect_data_files('antares.study.version.create_app.resources')
+datas = collect_data_files("antares.study.version.create_app.resources")

--- a/src/antares/study/version/__pyinstaller/hook-antares.study.version.py
+++ b/src/antares/study/version/__pyinstaller/hook-antares.study.version.py
@@ -1,5 +1,3 @@
 from PyInstaller.utils.hooks import collect_data_files
 
-hiddenimports = ["antares.study.version.create_app.resources"]
-
 datas = collect_data_files("antares.study.version.create_app.resources")

--- a/src/antares/study/version/__pyinstaller/hook-antares.study.version.py
+++ b/src/antares/study/version/__pyinstaller/hook-antares.study.version.py
@@ -1,3 +1,5 @@
 from PyInstaller.utils.hooks import collect_data_files
 
+hiddenimports = ['antares.study.version.create_app.resources']
+
 datas = collect_data_files('antares.study.version.create_app.resources')

--- a/src/antares/study/version/create_app/__init__.py
+++ b/src/antares/study/version/create_app/__init__.py
@@ -1,5 +1,6 @@
 import dataclasses
 import datetime
+import sys
 import typing as t
 import zipfile
 from pathlib import Path
@@ -19,8 +20,9 @@ def get_template_version(template_name: str) -> StudyVersion:
 
 
 TEMPLATES_BY_VERSIONS: t.Dict[StudyVersion, str] = {}
-REL_RESOURCES_PATH = _RESOURCES_PATH.relative_to(Path.cwd())
-for resource in REL_RESOURCES_PATH.iterdir():
+if getattr(sys, 'frozen', False) and hasattr(sys, '_MEIPASS'):
+    _RESOURCES_PATH = Path(sys._MEIPASS) / "resources"
+for resource in _RESOURCES_PATH.iterdir():
     if resource.name.endswith(".zip"):
         TEMPLATES_BY_VERSIONS[get_template_version(resource.name)] = resource.name
 

--- a/src/antares/study/version/create_app/__init__.py
+++ b/src/antares/study/version/create_app/__init__.py
@@ -19,7 +19,8 @@ def get_template_version(template_name: str) -> StudyVersion:
 
 
 TEMPLATES_BY_VERSIONS: t.Dict[StudyVersion, str] = {}
-for resource in _RESOURCES_PATH.iterdir():
+REL_RESOURCES_PATH = _RESOURCES_PATH.relative_to(HERE.parent)
+for resource in REL_RESOURCES_PATH.iterdir():
     if resource.name.endswith(".zip"):
         TEMPLATES_BY_VERSIONS[get_template_version(resource.name)] = resource.name
 

--- a/src/antares/study/version/create_app/__init__.py
+++ b/src/antares/study/version/create_app/__init__.py
@@ -1,21 +1,15 @@
 import dataclasses
 import datetime
-import sys
 import typing as t
 import zipfile
+from importlib.resources import contents, open_binary
 from pathlib import Path
 
 from antares.study.version.exceptions import ApplicationError
 from antares.study.version.model.study_antares import StudyAntares
 from antares.study.version.model.study_version import StudyVersion
 
-HERE = Path(__file__).resolve()
-_RESOURCES_PATH = HERE.parent / "resources"
-# If the application is running in a frozen state (e.g., packaged with PyInstaller),
-# set the resources path to the temporary directory (_MEIPASS) created by PyInstaller.
-# details here : https://pyinstaller.org/en/stable/runtime-information.html
-if getattr(sys, "frozen", False) and hasattr(sys, "_MEIPASS"):
-    _RESOURCES_PATH = Path(sys._MEIPASS) / "resources"
+_RESOURCES_PACKAGE = "antares.study.version.create_app.resources"
 
 
 def get_template_version(template_name: str) -> StudyVersion:
@@ -24,10 +18,9 @@ def get_template_version(template_name: str) -> StudyVersion:
     return StudyVersion.parse(version_str)
 
 
-TEMPLATES_BY_VERSIONS: t.Dict[StudyVersion, str] = {}
-for resource in _RESOURCES_PATH.iterdir():
-    if resource.name.endswith(".zip"):
-        TEMPLATES_BY_VERSIONS[get_template_version(resource.name)] = resource.name
+TEMPLATES_BY_VERSIONS: t.Dict[StudyVersion, str] = {
+    get_template_version(name): name for name in contents(_RESOURCES_PACKAGE) if name.endswith(".zip")
+}
 
 
 def available_versions() -> t.List[str]:
@@ -68,9 +61,10 @@ class CreateApp:
             msg = f"No available template for version {self.version}: available templates are {available_versions()}"
             raise ApplicationError(msg)
         print(f"Extracting template {template_name} to '{self.study_dir}'...")
-        resource_path = _RESOURCES_PATH / template_name
-        with zipfile.ZipFile(resource_path, mode="r") as archive:
-            archive.extractall(self.study_dir)
+        with open_binary(_RESOURCES_PACKAGE, template_name) as zip_file:
+            with zipfile.ZipFile(zip_file, mode="r") as archive:
+                archive.extractall(self.study_dir)
+
         creation_date = datetime.datetime.now()
         study_antares = StudyAntares(
             version=self.version,

--- a/src/antares/study/version/create_app/__init__.py
+++ b/src/antares/study/version/create_app/__init__.py
@@ -19,8 +19,7 @@ def get_template_version(template_name: str) -> StudyVersion:
 
 
 TEMPLATES_BY_VERSIONS: t.Dict[StudyVersion, str] = {}
-REL_RESOURCES_PATH = _RESOURCES_PATH.relative_to(Path.cwd())
-for resource in REL_RESOURCES_PATH.iterdir():
+for resource in _RESOURCES_PATH.iterdir():
     if resource.name.endswith(".zip"):
         TEMPLATES_BY_VERSIONS[get_template_version(resource.name)] = resource.name
 

--- a/src/antares/study/version/create_app/__init__.py
+++ b/src/antares/study/version/create_app/__init__.py
@@ -19,7 +19,7 @@ def get_template_version(template_name: str) -> StudyVersion:
 
 
 TEMPLATES_BY_VERSIONS: t.Dict[StudyVersion, str] = {}
-REL_RESOURCES_PATH = _RESOURCES_PATH.relative_to(HERE.parent)
+REL_RESOURCES_PATH = _RESOURCES_PATH.relative_to(Path.cwd())
 for resource in REL_RESOURCES_PATH.iterdir():
     if resource.name.endswith(".zip"):
         TEMPLATES_BY_VERSIONS[get_template_version(resource.name)] = resource.name

--- a/src/antares/study/version/create_app/__init__.py
+++ b/src/antares/study/version/create_app/__init__.py
@@ -1,5 +1,5 @@
 import dataclasses
-
+import datetime
 import sys
 import typing as t
 import zipfile

--- a/src/antares/study/version/create_app/__init__.py
+++ b/src/antares/study/version/create_app/__init__.py
@@ -2,14 +2,14 @@ import dataclasses
 import datetime
 import typing as t
 import zipfile
-from importlib.resources import contents, open_binary
 from pathlib import Path
 
 from antares.study.version.exceptions import ApplicationError
 from antares.study.version.model.study_antares import StudyAntares
 from antares.study.version.model.study_version import StudyVersion
 
-_RESOURCES_PACKAGE = "antares.study.version.create_app.resources"
+HERE = Path(__file__).resolve()
+_RESOURCES_PATH = HERE.parent / "resources"
 
 
 def get_template_version(template_name: str) -> StudyVersion:
@@ -18,9 +18,11 @@ def get_template_version(template_name: str) -> StudyVersion:
     return StudyVersion.parse(version_str)
 
 
-TEMPLATES_BY_VERSIONS: t.Dict[StudyVersion, str] = {
-    get_template_version(name): name for name in contents(_RESOURCES_PACKAGE) if name.endswith(".zip")
-}
+TEMPLATES_BY_VERSIONS: t.Dict[StudyVersion, str] = {}
+REL_RESOURCES_PATH = _RESOURCES_PATH.relative_to(Path.cwd())
+for resource in REL_RESOURCES_PATH.iterdir():
+    if resource.name.endswith(".zip"):
+        TEMPLATES_BY_VERSIONS[get_template_version(resource.name)] = resource.name
 
 
 def available_versions() -> t.List[str]:
@@ -61,10 +63,9 @@ class CreateApp:
             msg = f"No available template for version {self.version}: available templates are {available_versions()}"
             raise ApplicationError(msg)
         print(f"Extracting template {template_name} to '{self.study_dir}'...")
-        with open_binary(_RESOURCES_PACKAGE, template_name) as zip_file:
-            with zipfile.ZipFile(zip_file, mode="r") as archive:
-                archive.extractall(self.study_dir)
-
+        resource_path = _RESOURCES_PATH / template_name
+        with zipfile.ZipFile(resource_path, mode="r") as archive:
+            archive.extractall(self.study_dir)
         creation_date = datetime.datetime.now()
         study_antares = StudyAntares(
             version=self.version,

--- a/src/antares/study/version/create_app/__init__.py
+++ b/src/antares/study/version/create_app/__init__.py
@@ -1,5 +1,5 @@
 import dataclasses
-import datetime
+
 import sys
 import typing as t
 import zipfile
@@ -11,6 +11,11 @@ from antares.study.version.model.study_version import StudyVersion
 
 HERE = Path(__file__).resolve()
 _RESOURCES_PATH = HERE.parent / "resources"
+# If the application is running in a frozen state (e.g., packaged with PyInstaller),
+# set the resources path to the temporary directory (_MEIPASS) created by PyInstaller.
+# details here : https://pyinstaller.org/en/stable/runtime-information.html
+if getattr(sys, "frozen", False) and hasattr(sys, "_MEIPASS"):
+    _RESOURCES_PATH = Path(sys._MEIPASS) / "resources"
 
 
 def get_template_version(template_name: str) -> StudyVersion:
@@ -20,8 +25,6 @@ def get_template_version(template_name: str) -> StudyVersion:
 
 
 TEMPLATES_BY_VERSIONS: t.Dict[StudyVersion, str] = {}
-if getattr(sys, 'frozen', False) and hasattr(sys, '_MEIPASS'):
-    _RESOURCES_PATH = Path(sys._MEIPASS) / "resources"
 for resource in _RESOURCES_PATH.iterdir():
     if resource.name.endswith(".zip"):
         TEMPLATES_BY_VERSIONS[get_template_version(resource.name)] = resource.name


### PR DESCRIPTION
We need to add a hook so Pyinstaller collect the files in antares.study.version.create_app.resources, otherwise Pyinstaller won't package these files and the library will crash the app when it's imported. 