### PR TITLE
feat(study): add editor field in study

### DIFF
--- a/src/antares/study/version/create_app/__init__.py
+++ b/src/antares/study/version/create_app/__init__.py
@@ -44,12 +44,14 @@ class CreateApp:
     caption: str
     version: StudyVersion
     author: str
+    editor: str = ""
 
     def __post_init__(self):
         self.study_dir = Path(self.study_dir)
         self.caption = self.caption.strip()
         self.version = StudyVersion.parse(self.version)
         self.author = self.author.strip()
+        self.editor = self.editor.strip()
         if self.study_dir.exists():
             raise FileExistsError(f"Study directory already exists: '{self.study_dir}'")
         if not self.caption:
@@ -72,6 +74,7 @@ class CreateApp:
             created_date=creation_date,
             last_save_date=creation_date,
             author=self.author,
+            editor=self.editor,
         )
         print("Writing 'study.antares' file...")
         study_antares.to_ini_file(self.study_dir, update_save_date=False)

--- a/src/antares/study/version/create_app/__init__.py
+++ b/src/antares/study/version/create_app/__init__.py
@@ -74,7 +74,7 @@ class CreateApp:
             created_date=creation_date,
             last_save_date=creation_date,
             author=self.author,
-            editor=self.editor,
+            editor=self.editor or self.author,
         )
         print("Writing 'study.antares' file...")
         study_antares.to_ini_file(self.study_dir, update_save_date=False)

--- a/src/antares/study/version/model/study_antares.py
+++ b/src/antares/study/version/model/study_antares.py
@@ -67,6 +67,7 @@ class StudyAntares:
     created_date: datetime.datetime
     last_save_date: datetime.datetime
     author: str
+    editor: str = ""
 
     # Conversion and validation methods
     # ---------------------------------
@@ -128,6 +129,7 @@ class StudyAntares:
             "created_date": int(self.created_date.timestamp()),
             "last_save_date": int(self.last_save_date.timestamp()),
             "author": self.author,
+            "editor": self.editor,
         }
 
     @classmethod
@@ -151,6 +153,7 @@ class StudyAntares:
             created_date=section["created"],  # type: ignore
             last_save_date=section["lastsave"],  # type: ignore
             author=section["author"],
+            editor=section.get("editor", ""),
         )
 
     def to_ini_file(self, study_dir: t.Union[str, Path], update_save_date: bool = True) -> None:
@@ -174,6 +177,7 @@ class StudyAntares:
 
         section_dict["created"] = section_dict.pop("created_date")
         section_dict["lastsave"] = section_dict.pop("last_save_date")
+        section_dict["editor"] = section_dict.pop("editor")
 
         parser = configparser.ConfigParser()
         parser["antares"] = section_dict

--- a/src/antares/study/version/model/study_antares.py
+++ b/src/antares/study/version/model/study_antares.py
@@ -147,13 +147,14 @@ class StudyAntares:
         parser = configparser.ConfigParser()
         parser.read(ini_path, encoding="utf-8")
         section = parser["antares"]
+        author = section["author"]
         return cls(
             caption=section["caption"],
             version=StudyVersion.parse(section["version"]),
             created_date=section["created"],  # type: ignore
             last_save_date=section["lastsave"],  # type: ignore
-            author=section["author"],
-            editor=section.get("editor", ""),
+            author=author,
+            editor=section.get("editor", author),
         )
 
     def to_ini_file(self, study_dir: t.Union[str, Path], update_save_date: bool = True) -> None:
@@ -177,7 +178,6 @@ class StudyAntares:
 
         section_dict["created"] = section_dict.pop("created_date")
         section_dict["lastsave"] = section_dict.pop("last_save_date")
-        section_dict["editor"] = section_dict.pop("editor")
 
         parser = configparser.ConfigParser()
         parser["antares"] = section_dict

--- a/tests/create_app/test_create_app.py
+++ b/tests/create_app/test_create_app.py
@@ -38,7 +38,7 @@ class TestCreateApp:
             "created": mock.ANY,
             "lastsave": mock.ANY,
             "version": expected_version,
-            "editor": "",
+            "editor": "Robert Smith",
         }
 
         created_date = datetime.datetime.fromtimestamp(ini_reader.getint("antares", "created"))
@@ -59,3 +59,16 @@ class TestCreateApp:
         ini_reader.read(study_antares_file, encoding="utf-8")
         properties = ini_reader["antares"]
         assert properties["editor"] == editor_name
+
+    def test_create_app_without_editor(self, tmp_path: Path):
+        study_dir = tmp_path.joinpath("my-new-study-with-editor")
+        study_version = StudyVersion.parse("8.4")
+        author = "Test Editor"
+        app = CreateApp(study_dir=study_dir, caption="My New App", version=study_version, author=author)
+        app()
+
+        study_antares_file = study_dir / "study.antares"
+        ini_reader = configparser.ConfigParser()
+        ini_reader.read(study_antares_file, encoding="utf-8")
+        properties = ini_reader["antares"]
+        assert properties["editor"] == author

--- a/tests/create_app/test_create_app.py
+++ b/tests/create_app/test_create_app.py
@@ -49,7 +49,9 @@ class TestCreateApp:
         study_dir = tmp_path.joinpath("my-new-study-with-editor")
         study_version = StudyVersion.parse("8.4")
         editor_name = "Test Editor"
-        app = CreateApp(study_dir=study_dir, caption="My New App", version=study_version, author="Robert Smith", editor=editor_name)
+        app = CreateApp(
+            study_dir=study_dir, caption="My New App", version=study_version, author="Robert Smith", editor=editor_name
+        )
         app()
 
         study_antares_file = study_dir / "study.antares"

--- a/tests/create_app/test_create_app.py
+++ b/tests/create_app/test_create_app.py
@@ -38,8 +38,22 @@ class TestCreateApp:
             "created": mock.ANY,
             "lastsave": mock.ANY,
             "version": expected_version,
+            "editor": "",
         }
 
         created_date = datetime.datetime.fromtimestamp(ini_reader.getint("antares", "created"))
         last_save_date = datetime.datetime.fromtimestamp(ini_reader.getint("antares", "lastsave"))
         assert last_save_date == created_date
+
+    def test_create_app_with_editor(self, tmp_path: Path):
+        study_dir = tmp_path.joinpath("my-new-study-with-editor")
+        study_version = StudyVersion.parse("8.4")
+        editor_name = "Test Editor"
+        app = CreateApp(study_dir=study_dir, caption="My New App", version=study_version, author="Robert Smith", editor=editor_name)
+        app()
+
+        study_antares_file = study_dir / "study.antares"
+        ini_reader = configparser.ConfigParser()
+        ini_reader.read(study_antares_file, encoding="utf-8")
+        properties = ini_reader["antares"]
+        assert properties["editor"] == editor_name

--- a/tests/show_app/test_show_app.py
+++ b/tests/show_app/test_show_app.py
@@ -25,6 +25,7 @@ class TestShowApp:
         actual = app.study_antares
         expected = {
             "author": "John Doe",
+            "editor": "",
             "caption": "Thermal fleet optimization",
             "created_date": datetime.datetime(2009, 7, 2, 8, 42, 15),
             "last_save_date": datetime.datetime(2023, 6, 7, 9, 1, 23),

--- a/tests/show_app/test_show_app.py
+++ b/tests/show_app/test_show_app.py
@@ -25,7 +25,7 @@ class TestShowApp:
         actual = app.study_antares
         expected = {
             "author": "John Doe",
-            "editor": "",
+            "editor": "John Doe",
             "caption": "Thermal fleet optimization",
             "created_date": datetime.datetime(2009, 7, 2, 8, 42, 15),
             "last_save_date": datetime.datetime(2023, 6, 7, 9, 1, 23),

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -63,6 +63,7 @@ class TestCli:
             "created": ANY,
             "lastsave": ANY,
             "author": "Jane Doe",
+            "editor": "",
         }
         assert expected == section_dict
         created_date = datetime.datetime.fromtimestamp(float(section_dict["created"]))
@@ -102,4 +103,5 @@ class TestCli:
             "created": mock.ANY,
             "lastsave": mock.ANY,
             "author": "Robert Smith",
+            "editor": "",
         }

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -63,7 +63,7 @@ class TestCli:
             "created": ANY,
             "lastsave": ANY,
             "author": "Jane Doe",
-            "editor": "",
+            "editor": "Jane Doe",
         }
         assert expected == section_dict
         created_date = datetime.datetime.fromtimestamp(float(section_dict["created"]))
@@ -103,5 +103,5 @@ class TestCli:
             "created": mock.ANY,
             "lastsave": mock.ANY,
             "author": "Robert Smith",
-            "editor": "",
+            "editor": "Robert Smith",
         }


### PR DESCRIPTION
Introduced an editor field to CreateApp and StudyAntares models, defaulting to an empty string for backward compatibility